### PR TITLE
add billid to dumb route message if there is add_billid param

### DIFF
--- a/modules/dumbchan.cpp
+++ b/modules/dumbchan.cpp
@@ -111,6 +111,11 @@ bool DumbDriver::msgExecute(Message& msg, String& dest)
     m.copyParam(msg,"timeout");
     m.copyParams(msg,msg.getValue("copyparams"));
 
+    if (msg.getBoolValue(YSTRING("add_billid"))) {
+    	Debug(this,DebugNote,"Call with 'add_billid' == true. Adding '%s' to call.route message.",c->billid().c_str());
+    	m.addParam("billid", c->billid());
+    }
+
     if (Engine::dispatch(m)) {
 	m = "call.execute";
 	m.addParam("callto",m.retValue());


### PR DESCRIPTION
Sorry for my bad english.
This papull-request will add billid to dumb channel route message if there is 'add_billid' param when dispatching call.execute. So we can start track call to dumb channel by this billid in message call.route.
